### PR TITLE
ascent

### DIFF
--- a/mods/_fd/ascent/README.md
+++ b/mods/_fd/ascent/README.md
@@ -1,7 +1,7 @@
 
 #### Список PRов:
 
-- Отсутствуют
+- https://github.com/RepoStash/FD-NewBay/pull/67
 <!--
   Ссылки на PRы, связанные с модом:
   - Создание
@@ -33,7 +33,8 @@ ID мода: ASCENT
   - `/datum/reagent/toxin/bromide/affect_ingest()`
   - `/datum/reagent/toxin/methyl_bromide/affect_touch()`
   - `/datum/reagent/toxin/methyl_bromide/affect_ingest()`
-
+- `code/yummy_organs.dm`:
+  - `/obj/item/reagent_containers/food/snacks/organ/use_before()`
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.
@@ -79,8 +80,9 @@ ID мода: ASCENT
 
 ### Авторы:
 
-Unknown
->https://github.com/Baystation12/Baystation12/commit/b5b3f37e9c15a8ac69be658187c1d5a79df85a34
+Danilcus
+>Unknown
+https://github.com/Baystation12/Baystation12/commit/b5b3f37e9c15a8ac69be658187c1d5a79df85a34
 <!--
   Здесь находится твой никнейм
   Если работал совместно - никнеймы тех, кто помогал.

--- a/mods/_fd/ascent/_ascent.dme
+++ b/mods/_fd/ascent/_ascent.dme
@@ -29,6 +29,7 @@
 #include "code/culture_ascent.dm"
 #include "code/location_ascent.dm"
 #include "code/religion_ascent.dm"
+#include "code/yummy_organs.dm"
 #include "code/~ascent.dm"
 
 #endif

--- a/mods/_fd/ascent/code/ascent_species.dm
+++ b/mods/_fd/ascent/code/ascent_species.dm
@@ -270,12 +270,6 @@
 		/singleton/emote/audible/ascent_hiss,
 		/singleton/emote/audible/ascent_purr,
 		/singleton/emote/audible/ascent_snarl,
-		/singleton/emote/visible/ascent_dazzle,
-		/singleton/emote/visible/ascent_flicker,
-		/singleton/emote/visible/ascent_glimmer,
-		/singleton/emote/visible/ascent_glint,
-		/singleton/emote/visible/ascent_pulse,
-		/singleton/emote/visible/ascent_shine,
 	)
 
 /datum/species/nabber/monarch_worker/skills_from_age(age)
@@ -358,12 +352,6 @@
 		/singleton/emote/audible/ascent_hiss,
 		/singleton/emote/audible/ascent_purr,
 		/singleton/emote/audible/ascent_snarl,
-		/singleton/emote/visible/ascent_dazzle,
-		/singleton/emote/visible/ascent_flicker,
-		/singleton/emote/visible/ascent_glimmer,
-		/singleton/emote/visible/ascent_glint,
-		/singleton/emote/visible/ascent_pulse,
-		/singleton/emote/visible/ascent_shine,
 	)
 
 /datum/species/nabber/monarch_queen/New()

--- a/mods/_fd/ascent/code/ascent_species.dm
+++ b/mods/_fd/ascent/code/ascent_species.dm
@@ -104,6 +104,18 @@
 		/datum/mob_descriptor/body_length = -2
 		)
 
+	default_emotes = list(
+		/singleton/emote/audible/ascent_hiss,
+		/singleton/emote/audible/ascent_purr,
+		/singleton/emote/audible/ascent_snarl,
+		/singleton/emote/visible/ascent_dazzle,
+		/singleton/emote/visible/ascent_flicker,
+		/singleton/emote/visible/ascent_glimmer,
+		/singleton/emote/visible/ascent_glint,
+		/singleton/emote/visible/ascent_pulse,
+		/singleton/emote/visible/ascent_shine,
+	)
+
 	pain_emotes_with_pain_level = list(
 			list(/singleton/emote/visible/ascent_shine, /singleton/emote/visible/ascent_dazzle) = 80,
 			list(/singleton/emote/visible/ascent_glimmer, /singleton/emote/visible/ascent_pulse) = 50,
@@ -254,6 +266,18 @@
 		TAG_RELIGION =  RELIGION_KHARMAANI
 	)
 
+	default_emotes = list(
+		/singleton/emote/audible/ascent_hiss,
+		/singleton/emote/audible/ascent_purr,
+		/singleton/emote/audible/ascent_snarl,
+		/singleton/emote/visible/ascent_dazzle,
+		/singleton/emote/visible/ascent_flicker,
+		/singleton/emote/visible/ascent_glimmer,
+		/singleton/emote/visible/ascent_glint,
+		/singleton/emote/visible/ascent_pulse,
+		/singleton/emote/visible/ascent_shine,
+	)
+
 /datum/species/nabber/monarch_worker/skills_from_age(age)
 	. = 0
 
@@ -323,13 +347,24 @@
 		/datum/mob_descriptor/body_length = -1
 		)
 
-
 	force_cultural_info = list(
 		TAG_CULTURE =   CULTURE_ASCENT,
 		TAG_HOMEWORLD = HOME_SYSTEM_KHARMAANI,
 		TAG_FACTION =   FACTION_ASCENT_SERPENTID,
 		TAG_RELIGION =  RELIGION_KHARMAANI
 		)
+
+	default_emotes = list(
+		/singleton/emote/audible/ascent_hiss,
+		/singleton/emote/audible/ascent_purr,
+		/singleton/emote/audible/ascent_snarl,
+		/singleton/emote/visible/ascent_dazzle,
+		/singleton/emote/visible/ascent_flicker,
+		/singleton/emote/visible/ascent_glimmer,
+		/singleton/emote/visible/ascent_glint,
+		/singleton/emote/visible/ascent_pulse,
+		/singleton/emote/visible/ascent_shine,
+	)
 
 /datum/species/nabber/monarch_queen/New()
 	equip_adjust = list(

--- a/mods/_fd/ascent/code/yummy_organs.dm
+++ b/mods/_fd/ascent/code/yummy_organs.dm
@@ -1,0 +1,32 @@
+/obj/item/reagent_containers/food/snacks/organ/use_before(mob/M as mob, mob/user as mob)
+	if (!istype(M, /mob/living/carbon))
+		return FALSE
+	if (!reagents || !reagents.total_volume)
+		to_chat(user, SPAN_DANGER("None of [src] left!"))
+		qdel(src)
+		return TRUE
+	if (!is_open_container())
+		to_chat(user, SPAN_NOTICE("\The [src] isn't open!"))
+		return TRUE
+
+	var/mob/living/carbon/C = M
+	var/fullness = C.get_fullness()
+	if(istype(C,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		if(!H.check_has_mouth())
+			to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
+			return TRUE
+		var/obj/item/blocked = H.check_mouth_coverage()
+		if(blocked)
+			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
+			return TRUE
+
+	if(fullness > 550)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)//puts a limit on how fast people can eat/drink things
+		to_chat(C, SPAN_DANGER("You cannot force any more of [src] to go down your throat."))
+		return TRUE
+
+	if(is_type_in_list(M, ALL_ASCENT_SPECIES))
+		reagents.del_reagent(/datum/reagent/toxin)
+
+	return ..()


### PR DESCRIPTION
Чинит эмоуты восхождения, добавляет оверрайд на органы

### Чейнджлог
```yml
🆑Danilcus
bugfix: Все расы восхождения вновь могут использовать свои эмоуты
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
